### PR TITLE
feature/KAS-3484-subcase-government-areas

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,8 +3,8 @@ import bodyParser from 'body-parser';
 
 import * as deltaUtil from './lib/delta-util';
 import { subjectIsTypeInGraph } from './util-queries';
-import { syncDocsForSubjectInGraph } from './case-doc-queries';
-import { GRAPH, UPDATEABLE_PREDICATES, WATCH_TYPES } from './config';
+import { syncObjectsForSubjectInGraph, unsyncObjectsForSubjectInGraph } from './case-doc-queries';
+import { GRAPH, UPDATEABLE_PREDICATES, WATCH_TYPES, CASE_FIELD_PREDICATE } from './config';
 
 app.post('/delta', bodyParser.json(), async (req, res) => {
   res.status(202).end();
@@ -23,9 +23,20 @@ app.post('/delta', bodyParser.json(), async (req, res) => {
   }
   for (const d of pathUpdates) {
     const subjectUri = d.subject.value;
-    const subjectType = WATCH_TYPES.find(t => t.predicateToDoc.uri === d.predicate.value).type;
+    const watchedType = WATCH_TYPES.find(t => t.predicateToObject.uri === d.predicate.value);
+    const subjectType = watchedType.type;
+    const casePredicate = watchedType.casePredicate;
     if (await subjectIsTypeInGraph(subjectUri, GRAPH, [subjectType])) {
-      await syncDocsForSubjectInGraph(d.subject.value, subjectType, GRAPH);
+      await syncObjectsForSubjectInGraph(d.subject.value, subjectType, GRAPH);
+      /* 
+        TODO KAS-3484 the reason for this block is to cleanup field relations found on case but not on the subjects.
+        This is really only useful for publications since they see the list but can't edit.
+        Mistakes (wrong added and removed) made by users will just keep existing unless we remove them here.
+        Only used for type fields. not safe to do for docs because of multiple subjects and legacy data.
+      */
+      if (casePredicate === CASE_FIELD_PREDICATE) {
+        await unsyncObjectsForSubjectInGraph(d.subject.value, subjectType, GRAPH);
+      }
     }
   }
 });

--- a/case-doc-queries.js
+++ b/case-doc-queries.js
@@ -1,23 +1,46 @@
 import { updateSudo } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeUri } from 'mu';
-import { CASE_TYPE, CASE_DOC_PREDICATE, WATCH_TYPES } from './config';
+import { CASE_TYPE, WATCH_TYPES } from './config';
 import { relationPathForType } from './lib/query-util';
 
-async function syncDocsForSubjectInGraph (subject, type, graph) {
-  const { predicateToDoc } = WATCH_TYPES.find(t => t.type === type);
+async function syncObjectsForSubjectInGraph (subject, type, graph) {
+  const { casePredicate, predicateToObject } = WATCH_TYPES.find(t => t.type === type);
   const queryString = `
 INSERT {
     GRAPH ${sparqlEscapeUri(graph)} {
-        ?case ${sparqlEscapeUri(CASE_DOC_PREDICATE)} ?doc .
+        ?case ${sparqlEscapeUri(casePredicate)} ?object .
     }
 }
 WHERE {
     GRAPH ${sparqlEscapeUri(graph)} {
         ?case a ${sparqlEscapeUri(CASE_TYPE)} .
         ${sparqlEscapeUri(subject)} ${relationPathForType(type)} ?case .
-        ${sparqlEscapeUri(subject)} ${sparqlEscapeUri(predicateToDoc.uri)} ?doc .
+        ${sparqlEscapeUri(subject)} ${sparqlEscapeUri(predicateToObject.uri)} ?object .
         FILTER NOT EXISTS {
-            ?case ${sparqlEscapeUri(CASE_DOC_PREDICATE)} ?doc .
+            ?case ${sparqlEscapeUri(casePredicate)} ?object .
+        }
+    }
+}
+  `;
+  await updateSudo(queryString);
+}
+
+async function unsyncObjectsForSubjectInGraph (subject, type, graph) {
+  const { casePredicate, predicateToObject } = WATCH_TYPES.find(t => t.type === type);
+  const queryString = `
+DELETE {
+    GRAPH ${sparqlEscapeUri(graph)} {
+        ?case ${sparqlEscapeUri(casePredicate)} ?object .
+    }
+}
+WHERE {
+    GRAPH ${sparqlEscapeUri(graph)} {
+        ?case a ${sparqlEscapeUri(CASE_TYPE)} .
+        ?case ${sparqlEscapeUri(casePredicate)} ?object .
+        ${sparqlEscapeUri(subject)} ${relationPathForType(type)} ?case .
+        ?anySubject ${relationPathForType(type)} ?case .
+        FILTER NOT EXISTS {
+            ?anySubject ${sparqlEscapeUri(predicateToObject.uri)} ?object .
         }
     }
 }
@@ -26,5 +49,6 @@ WHERE {
 }
 
 module.exports = {
-  syncDocsForSubjectInGraph
+  syncObjectsForSubjectInGraph,
+  unsyncObjectsForSubjectInGraph
 };

--- a/config.js
+++ b/config.js
@@ -2,33 +2,45 @@ const GRAPH = 'http://mu.semte.ch/graphs/organizations/kanselarij';
 
 const CASE_TYPE = 'https://data.vlaanderen.be/ns/dossier#Dossier';
 const CASE_DOC_PREDICATE = 'https://data.vlaanderen.be/ns/dossier#Dossier.bestaatUit';
+const CASE_FIELD_PREDICATE = 'http://data.vlaanderen.be/ns/besluitvorming#beleidsveld';
 
 const WATCH_TYPES = [
   {
     type: 'http://data.vlaanderen.be/ns/besluit#Agendapunt',
-    predicateToDoc: { uri: 'http://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk', inverse: false },
+    predicateToObject: { uri: 'http://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk', inverse: false },
     pathToCase: [
       { uri: 'http://data.vlaanderen.be/ns/besluitvorming#genereertAgendapunt', inverse: true },
       { uri: 'http://data.vlaanderen.be/ns/besluitvorming#vindtPlaatsTijdens', inverse: false },
       { uri: 'https://data.vlaanderen.be/ns/dossier#doorloopt', inverse: true }
-    ]
+    ],
+    casePredicate: CASE_DOC_PREDICATE
   },
   {
     type: 'http://mu.semte.ch/vocabularies/ext/Indieningsactiviteit',
-    predicateToDoc: { uri: 'http://www.w3.org/ns/prov#generated', inverse: false },
+    predicateToObject: { uri: 'http://www.w3.org/ns/prov#generated', inverse: false },
     pathToCase: [
       { uri: 'http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens', inverse: false },
       { uri: 'https://data.vlaanderen.be/ns/dossier#doorloopt', inverse: true }
-    ]
+    ],
+    casePredicate: CASE_DOC_PREDICATE
+  },
+  {
+    type: 'https://data.vlaanderen.be/ns/dossier#Procedurestap',
+    predicateToObject: { uri: 'http://data.vlaanderen.be/ns/besluitvorming#beleidsveld', inverse: false },
+    pathToCase: [
+      { uri: 'https://data.vlaanderen.be/ns/dossier#doorloopt', inverse: true }
+    ],
+    casePredicate: CASE_FIELD_PREDICATE
   }
 ];
 
-const UPDATEABLE_PREDICATES = WATCH_TYPES.map(t => t.predicateToDoc.uri);
+const UPDATEABLE_PREDICATES = WATCH_TYPES.map(t => t.predicateToObject.uri);
 
 module.exports = {
   GRAPH,
   CASE_TYPE,
   CASE_DOC_PREDICATE,
+  CASE_FIELD_PREDICATE,
   WATCH_TYPES,
   UPDATEABLE_PREDICATES
 };


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3484

- added mappings to `WATCH_TYPES`
- added the INSERT predicate to those mappings to determine docs or fields delta.
- Changed existing query to be more configurable to not only be used for docs
- rename some doc specific variables.
- added query to unsync, but only for fields

Note:
The more I got into this service, the more I realized the query was not really 'generic'.
I then changed the query instead since I was already invested in going for the "1 generic query for everything" route.

Maybe it would be better to have specific queries for each, and do better splitting up when receiving the deltas.
